### PR TITLE
Updated pagination system

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Filter.js is client-side JSON objects filter and render html elements.
 Multiple filter criteria can be specified and used in conjunction with
 each other.
 
+Basic plugin is made by Jiren Patel (https://github.com/jiren), i added an pagination system.
+
 
 Usage
 -----
@@ -90,6 +92,25 @@ To render each json object require view template. In filter.js micro-templating 
        </div>
 	</script>
 ```
+
+### Pagination
+-------------------
+
+By default the plugin uses the following configuration.
+All settings are optional and can be changed within Filter Initialisation.
+
+```
+  {
+    page: 1,
+    prevText: '&laquo;',
+    nextText: '&raquo;',
+    perPage: 12,
+    range: 5,
+    pagination_container: '.pagination',
+    noresults_container: '#noresults'
+  } 
+```
+
 
 ### Filter Criteria
 -------------------

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Multiple filter criteria can be specified and used in conjunction with
 each other.
 
 Basic plugin is made by Jiren Patel (https://github.com/jiren), i added an pagination system.
+Demo: http://github.die-coder.de/filter.js/examples/index.html
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -322,28 +322,8 @@ Demo
 To see the sample demo, clone this repo and open demo/filterjs.html in your browser
 
 [Filter](http://jiren.github.io/filter.js/index.html)
+[Pagination](http://github.die-coder.de/filter.js/examples/index.html)
 
-
-USED BY
---------
-
-[Tischefrei (search page)](http://tischefrei.de)
-
-[Roboty przemysłowe](http://roboty-przemyslowe.pl)
-
-If you use this, please send me an email, I shall add your link here!
-
-
-Sponsors and Supporters
------------------------
-
-- [Josh Software](http://www.joshsoftware.com)
-
-- Instant search field filtering sponsored by [W/E consultants](http://www.w-e.nl)
-
-Contributing
-------------
-Please send me a pull request so that this can be improved.
 
 License
 -------

--- a/examples/index.html
+++ b/examples/index.html
@@ -152,12 +152,17 @@
               <input type="checkbox" value="Sport"> Sport
             </label>
         </div></div>
+      </div>
 
+      <div class="content col-span-9">
+        <div class="sorting"></div>
+        <div class="pagination"></div>
+        <div id="noresults" class="thumbnail">
+          <h4>No results are found.</h4>
+        </div>
+        <div class="movies" id="movies"></div>
       </div>
-      <div class="sorting content col-span-9">
-      </div>
-      <div class="movies content col-span-9" id="movies">
-      </div>
+
       <script id="movie-template" type="text/html">
         <div class="col-span-4 movie">
           <div class="thumbnail">

--- a/examples/index.js
+++ b/examples/index.js
@@ -10,6 +10,15 @@ $(document).ready(function(){
       afterFilter: function(result){
         $('#total_movies').text(result.length);
       }
+	},
+	// pagination settings
+	pagination: {
+	  perPage: 6,
+	  range: 3,
+	  prevText: 'prev',
+	  nextText: 'next',
+	  pagination_container: '.pagination',
+	  noresults_container: '#noresults'
     }
   });
 

--- a/filter.js
+++ b/filter.js
@@ -49,12 +49,8 @@
       self.addCriteria(this);
     });
 
-    this.Model = JsonQuery();
-    this.Model.getterFns['_fid'] = function(r){ return r['_fid'];};
-    this.addRecords(records);
-
-    // Pagination
-    this.pagination = {
+	// pagination
+	this.pagination = {
 	  page: 1,
 	  prevText: this.opts.pagination.prevText || '&laquo;',
 	  nextText: this.opts.pagination.nextText || '&raquo;',
@@ -62,7 +58,12 @@
 	  range: this.opts.pagination.range || 5,
 	  pagination_container: this.opts.pagination.pagination_container || '.pagination',
 	  noresults_container: this.opts.pagination.noresults_container || '#noresults'
-    };
+	};
+	// pagination end
+
+    this.Model = JsonQuery();
+    this.Model.getterFns['_fid'] = function(r){ return r['_fid'];};
+    this.addRecords(records);
   };
 
   var F = FJS.prototype;


### PR DESCRIPTION
I've updated the pagination system to the current version of filter.js.

As before you have to add two containers to the HTML: One to render the pagination in (default:  '.pagination'), a second one to display if no results are found (default: '#noresults').
There are no required changes in the plugin initialization itself, but you can configure the default options there:

```
{
    perPage: 12,
    range: 5,
    prevText: '&laquo;',
    nextText: '&raquo;',
    pagination_container: '.pagination',
    noresults_container: '#noresults'
} 
```