### PR TITLE
Ref #124 - Convert inputs of entity HTML to simble

### DIFF
--- a/dist/filter.js
+++ b/dist/filter.js
@@ -824,7 +824,17 @@
                       .replace(/\//g, '&#x2F;');
   };
   
+  var convertHtmlEntityToStr = function(string) {
+    return (''+string).replace(/&amp;/g, '&')
+                      .replace(/&lt;/g, '<')
+                      .replace(/&gt;/g, '>')
+                      .replace(/&quot;/g, '\"')
+                      .replace(/&#x27;/g, '\'')
+                      .replace(/&#x2F;/g, '\/');
+  };
+  
   function templateBuilder(str, data) {
+    str = convertHtmlEntityToStr(str);
     var c  = templateSettings;
     var tmpl = 'var __p=[],print=function(){__p.push.apply(__p,arguments);};' +
       'with(obj||{}){__p.push(\'' +


### PR DESCRIPTION
To use the lib with reactJs is required to replace the HTML entity code to string, before replace the template.

In JSX I can't use the "<%=" token, therefore I need convert to HTML entity code("&lt;%=") that I received of ReactJs and after converts it again.

With this simple change you can integrate the lib with ReactJs.