### PR TITLE
FIX: parseValues fails when no schema is found

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -581,7 +581,7 @@ F.renderPagination = function(totalCount){
 };
 
 F.parseValues = function(field, values){
-  var type = this.Model.schema[field];
+  var type = typeof this.Model.schema == 'undefined' ? 'String' : this.Model.schema[field];
 
   if(type == 'Number'){
     return $.map(values, function(v){ return Number(v) }); 


### PR DESCRIPTION
Schema is expected. Nevertheless, If there are no records, no schema will be found, hence failing.